### PR TITLE
Directory to download the model has changed

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -14,7 +14,7 @@
 gpt2_download <- function(model = c("124M", "355M", "774M", "1558M")) {
   model <- match.arg(model, c("124M", "355M", "774M", "1558M"))
 
-  model_base <- paste0("https://storage.googleapis.com/gpt-2/models/", model, "/")
+  model_base <- paste0("https://openaipublic.blob.core.windows.net/gpt-2/models/", model, "/")
   model_files <- c("checkpoint", "encoder.json", "hparams.json", "model.ckpt.data-00000-of-00001", "model.ckpt.index", "model.ckpt.meta", "vocab.bpe")
   model_urls <- paste0(model_base, model_files)
 


### PR DESCRIPTION
Hi,
An error is raised when the models are download (gpt2_download) because the directory has changed according https://github.com/openai/gpt-2/blob/master/download_model.py

#7 

Thanks 